### PR TITLE
Update API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ const someValue = {
 
 console.log(someValue); // { a: 1, b: 2, c: [ 1, 2, 3 ] }
 
-const state = new ObjectState();
-state.set(someValue);
+const state = new ObjectState(someValue);
 
 someValue.b = 200;
 someValue.x = 42;
@@ -40,7 +39,7 @@ someValue.c.push(9);
 
 console.log(someValue); // { a: 1, b: 200, c: [ 1, 2, 3, 9 ], x: 42 }
 
-state.rollback(someValue);
+state.rollback();
 
 console.log(someValue); // { a: 1, b: 2, c: [ 1, 2, 3 ] }
 ```

--- a/readme-template.mustache
+++ b/readme-template.mustache
@@ -37,8 +37,7 @@ const someValue = {
 
 console.log(someValue); // { a: 1, b: 2, c: [ 1, 2, 3 ] }
 
-const state = new ObjectState();
-state.set(someValue);
+const state = new ObjectState(someValue);
 
 someValue.b = 200;
 someValue.x = 42;
@@ -46,7 +45,7 @@ someValue.c.push(9);
 
 console.log(someValue); // { a: 1, b: 200, c: [ 1, 2, 3, 9 ], x: 42 }
 
-state.rollback(someValue);
+state.rollback();
 
 console.log(someValue); // { a: 1, b: 2, c: [ 1, 2, 3 ] }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,36 +1,46 @@
 import { DefaultStateClass, stateClassList, StateInterface } from './state';
 import { isNotPrimitive } from './utils';
 
-export class ObjectState {
-    private __objectStateMap: WeakMap<object, StateInterface>;
+export class ObjectState<T> {
+    private readonly __value: T;
+    private readonly __objectStateMap: WeakMap<object, StateInterface>;
 
-    public constructor(...values: unknown[]) {
-        this.__objectStateMap = new WeakMap();
-        for (const value of values) {
-            this.set(value);
+    public constructor(value: T) {
+        const argsLen = arguments.length;
+        const className = new.target.name;
+        if (argsLen < 1) {
+            throw new TypeError(`Constructor ${className} requires 1 argument`);
+        } else if (argsLen > 1) {
+            throw new TypeError(
+                `Constructor ${className} requires only 1 argument`,
+            );
         }
-    }
 
-    public set(value: unknown): this {
+        this.__value = value;
+        this.__objectStateMap = new WeakMap();
+        Object.defineProperties(this, {
+            __value: {
+                writable: false,
+                enumerable: false,
+                configurable: false,
+            },
+            __objectStateMap: {
+                writable: false,
+                enumerable: false,
+                configurable: false,
+            },
+        });
+
         if (isNotPrimitive(value)) {
-            if (this.__objectStateMap.has(value)) {
-                throw new Error('The specified value has already been set');
-            }
             this.__set(value);
         }
-        return this;
     }
 
-    public rollback<T>(value: T): T {
-        if (isNotPrimitive(value)) {
-            if (!this.__objectStateMap.has(value)) {
-                throw new RangeError(
-                    'The specified value has not been set yet',
-                );
-            }
-            this.__rollback(value);
+    public rollback(): T {
+        if (isNotPrimitive(this.__value)) {
+            this.__rollback(this.__value);
         }
-        return value;
+        return this.__value;
     }
 
     private __set(value: object): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { DefaultStateClass, stateClassList, StateInterface } from './state';
-import { isNotPrimitive } from './utils';
+import { freezeProperties, isNotPrimitive } from './utils';
 
 export class ObjectState<T> {
     private readonly __value: T;
@@ -18,18 +18,7 @@ export class ObjectState<T> {
 
         this.__value = value;
         this.__objectStateMap = new WeakMap();
-        Object.defineProperties(this, {
-            __value: {
-                writable: false,
-                enumerable: false,
-                configurable: false,
-            },
-            __objectStateMap: {
-                writable: false,
-                enumerable: false,
-                configurable: false,
-            },
-        });
+        freezeProperties(this, ['__value', '__objectStateMap']);
 
         if (isNotPrimitive(value)) {
             this.__set(value);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,23 @@ export function objectAllEntries<T>(
         value[propName],
     ]);
 }
+
+export function freezeProperties(
+    value: object,
+    properties: ReadonlyArray<string>,
+): void {
+    Object.defineProperties(
+        value,
+        properties.reduce<PropertyDescriptorMap>(
+            (descMap, propName) => ({
+                ...descMap,
+                [propName]: {
+                    writable: false,
+                    enumerable: false,
+                    configurable: false,
+                },
+            }),
+            {},
+        ),
+    );
+}

--- a/test/api.ts
+++ b/test/api.ts
@@ -6,68 +6,50 @@ import values from './helpers/values';
 import objectValues from './helpers/values/object';
 import primitiveValues from './helpers/values/primitive';
 
-test('set() method should be possible to be called multiple times with the same primitive value', t => {
-    const state = new ObjectState();
-    for (const targetValue of primitiveValues) {
+for (const targetValue of primitiveValues) {
+    const testNameSuffix = inspectValue({ targetValue });
+    test(`Constructor should accept primitive value argument / ${testNameSuffix}`, t => {
+        t.notThrows(() => new ObjectState(targetValue));
+    });
+}
+
+for (const targetValue of objectValues) {
+    const testNameSuffix = inspectValue({ targetValue });
+    test(`Constructor should accept object value argument / ${testNameSuffix}`, t => {
+        t.notThrows(() => new ObjectState(targetValue));
+    });
+}
+
+test('Constructor should not accept less than 1 argument', t => {
+    t.throws(() => new ObjectState(), {
+        instanceOf: TypeError,
+        message: `Constructor ${ObjectState.name} requires 1 argument`,
+    });
+});
+
+test('Constructor should not accept more than one argument', t => {
+    t.throws(() => new ObjectState({}, {}), {
+        instanceOf: TypeError,
+        message: `Constructor ${ObjectState.name} requires only 1 argument`,
+    });
+});
+
+for (const targetValue of values) {
+    const testNameSuffix = inspectValue({ targetValue });
+
+    test(`rollback() method should return the original value / ${testNameSuffix}`, t => {
         t.notThrows(() => {
-            state.set(targetValue);
-            state.set(targetValue);
-        }, `targetValue: ${inspectValue(targetValue)}`);
-    }
-});
+            const state = new ObjectState(targetValue);
+            t.is(state.rollback(), targetValue);
+        });
+    });
 
-test('set() method should not be possible to call multiple times with the same object value', t => {
-    const state = new ObjectState();
-    for (const targetValue of objectValues) {
-        t.throws(
-            () => {
-                state.set(targetValue);
-                state.set(targetValue);
-            },
-            {
-                message: /(^|\W)The specified value has already been set(\W|$)/i,
-            },
-            'targetValue: ' +
-                inspectValue(targetValue, { filstLineOnly: true }),
-        );
-    }
-});
-
-test('rollback() of primitive values not set yet should success', t => {
-    const state = new ObjectState();
-    for (const targetValue of primitiveValues) {
+    test(`rollback() method should be possible to be called multiple times / ${testNameSuffix}`, t => {
         t.notThrows(() => {
-            state.rollback(targetValue);
-        }, `targetValue: ${inspectValue(targetValue)}`);
-    }
-});
-
-test('rollback() of object values not set yet should fail', t => {
-    const state = new ObjectState();
-    for (const targetValue of objectValues) {
-        t.throws(
-            () => {
-                state.rollback(targetValue);
-            },
-            {
-                instanceOf: RangeError,
-                message: /(^|\W)The specified value has not been set yet(\W|$)/i,
-            },
-            'targetValue: ' +
-                inspectValue(targetValue, { filstLineOnly: true }),
-        );
-    }
-});
-
-test('rollback() method should return the original value', t => {
-    const state = new ObjectState();
-    for (const targetValue of values) {
-        state.set(targetValue);
-        t.is(
-            state.rollback(targetValue),
-            targetValue,
-            'targetValue: ' +
-                inspectValue(targetValue, { filstLineOnly: true }),
-        );
-    }
-});
+            const state = new ObjectState(targetValue);
+            for (let i = 1; i <= 5; i++) {
+                t.notThrows(() => state.rollback(), inspectValue({ i }));
+            }
+        });
+    });
+}

--- a/test/api.ts
+++ b/test/api.ts
@@ -21,17 +21,29 @@ for (const targetValue of objectValues) {
 }
 
 test('Constructor should not accept less than 1 argument', t => {
-    t.throws(() => new ObjectState(), {
-        instanceOf: TypeError,
-        message: `Constructor ${ObjectState.name} requires 1 argument`,
-    });
+    t.throws(
+        () =>
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore TS2554: Expected 1 arguments, but got 0.
+            new ObjectState(),
+        {
+            instanceOf: TypeError,
+            message: `Constructor ${ObjectState.name} requires 1 argument`,
+        },
+    );
 });
 
 test('Constructor should not accept more than one argument', t => {
-    t.throws(() => new ObjectState({}, {}), {
-        instanceOf: TypeError,
-        message: `Constructor ${ObjectState.name} requires only 1 argument`,
-    });
+    t.throws(
+        () =>
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore TS2554: Expected 1 arguments, but got 2.
+            new ObjectState({}, {}),
+        {
+            instanceOf: TypeError,
+            message: `Constructor ${ObjectState.name} requires only 1 argument`,
+        },
+    );
 });
 
 for (const targetValue of values) {

--- a/test/helpers/values/object/error.ts
+++ b/test/helpers/values/object/error.ts
@@ -1,1 +1,4 @@
-export default [new Error('msg')];
+export default [new Error('msg')].map(error => {
+    error.stack = String(error);
+    return error;
+});

--- a/test/rollback-value/array.ts
+++ b/test/rollback-value/array.ts
@@ -8,14 +8,13 @@ test('should rollback array items', async t => {
     const value = [1, 2, 3];
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value[1] **= 6;
     value.push(Infinity);
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -23,8 +22,7 @@ test('should rollback array object properties', t => {
     const value = [true, false, null, NaN];
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     Object.assign(value, {
         x: 1,
@@ -33,7 +31,7 @@ test('should rollback array object properties', t => {
     });
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -41,15 +39,14 @@ test('should rollback array items order', async t => {
     const value = [1, 2, 3, 4, 5];
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.length = 0;
     value.push(2, 4, 1, 5, 3);
     t.deepEqual(sortList(value), sortList(origValueStruct));
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -57,13 +54,12 @@ test('should rollback empty array', async t => {
     const value = Array(4);
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value[1] = null;
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -72,13 +68,12 @@ test('should rollback nested array items', t => {
     const value = [0, item, 1, 2];
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     item[1] = item[1].toUpperCase();
     item[9] = 'nine';
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });

--- a/test/rollback-value/buffer.ts
+++ b/test/rollback-value/buffer.ts
@@ -6,14 +6,13 @@ test('should rollback Buffer value', async t => {
     const value = Buffer.from('abcdefgh');
     const origValueStruct = Buffer.from(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value[1] = 0xff;
     value.fill(0x00, 4);
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -21,8 +20,7 @@ test('should rollback Buffer object properties', t => {
     const value = Buffer.from('foo');
     const origValueStruct = Buffer.from(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     Object.assign(value, {
         x: 1,
@@ -32,6 +30,6 @@ test('should rollback Buffer object properties', t => {
     });
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });

--- a/test/rollback-value/data-view.ts
+++ b/test/rollback-value/data-view.ts
@@ -6,13 +6,12 @@ test('should rollback DataView value / Int8', async t => {
     const value = new DataView(new ArrayBuffer(1));
     value.setInt8(0, 1);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.setInt8(0, 2);
     t.not(value.getInt8(0), 1);
 
-    state.rollback(value);
+    state.rollback();
     t.is(value.getInt8(0), 1);
 });
 
@@ -20,13 +19,12 @@ test('should rollback DataView value / Uint8', async t => {
     const value = new DataView(new ArrayBuffer(1));
     value.setUint8(0, 1);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.setUint8(0, 2);
     t.not(value.getUint8(0), 1);
 
-    state.rollback(value);
+    state.rollback();
     t.is(value.getUint8(0), 1);
 });
 
@@ -34,13 +32,12 @@ test('should rollback DataView value / Int16', async t => {
     const value = new DataView(new ArrayBuffer(2));
     value.setInt16(0, 1);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.setInt16(0, 2);
     t.not(value.getInt16(0), 1);
 
-    state.rollback(value);
+    state.rollback();
     t.is(value.getInt16(0), 1);
 });
 
@@ -48,13 +45,12 @@ test('should rollback DataView value / Uint16', async t => {
     const value = new DataView(new ArrayBuffer(2));
     value.setUint16(0, 1);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.setUint16(0, 2);
     t.not(value.getUint16(0), 1);
 
-    state.rollback(value);
+    state.rollback();
     t.is(value.getUint16(0), 1);
 });
 
@@ -62,13 +58,12 @@ test('should rollback DataView value / Int32', async t => {
     const value = new DataView(new ArrayBuffer(4));
     value.setInt32(0, 1);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.setInt32(0, 2);
     t.not(value.getInt32(0), 1);
 
-    state.rollback(value);
+    state.rollback();
     t.is(value.getInt32(0), 1);
 });
 
@@ -76,13 +71,12 @@ test('should rollback DataView value / Uint32', async t => {
     const value = new DataView(new ArrayBuffer(4));
     value.setUint32(0, 1);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.setUint32(0, 2);
     t.not(value.getUint32(0), 1);
 
-    state.rollback(value);
+    state.rollback();
     t.is(value.getUint32(0), 1);
 });
 
@@ -90,13 +84,12 @@ test('should rollback DataView value / Float32', async t => {
     const value = new DataView(new ArrayBuffer(4));
     value.setFloat32(0, 1);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.setFloat32(0, 2);
     t.not(value.getFloat32(0), 1);
 
-    state.rollback(value);
+    state.rollback();
     t.is(value.getFloat32(0), 1);
 });
 
@@ -104,13 +97,12 @@ test('should rollback DataView value / Float64', async t => {
     const value = new DataView(new ArrayBuffer(8));
     value.setFloat64(0, 1);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.setFloat64(0, 2);
     t.not(value.getFloat64(0), 1);
 
-    state.rollback(value);
+    state.rollback();
     t.is(value.getFloat64(0), 1);
 });
 
@@ -122,13 +114,12 @@ if (
         const value = new DataView(new ArrayBuffer(8));
         value.setBigInt64(0, BigInt(1)); // eslint-disable-line no-undef
 
-        const state = new ObjectState();
-        state.set(value);
+        const state = new ObjectState(value);
 
         value.setBigInt64(0, BigInt(2)); // eslint-disable-line no-undef
         t.not(value.getBigInt64(0), BigInt(1)); // eslint-disable-line no-undef
 
-        state.rollback(value);
+        state.rollback();
         t.is(value.getBigInt64(0), BigInt(1)); // eslint-disable-line no-undef
     });
 }
@@ -141,13 +132,12 @@ if (
         const value = new DataView(new ArrayBuffer(8));
         value.setBigUint64(0, BigInt(1)); // eslint-disable-line no-undef
 
-        const state = new ObjectState();
-        state.set(value);
+        const state = new ObjectState(value);
 
         value.setBigUint64(0, BigInt(2)); // eslint-disable-line no-undef
         t.not(value.getBigUint64(0), BigInt(1)); // eslint-disable-line no-undef
 
-        state.rollback(value);
+        state.rollback();
         t.is(value.getBigUint64(0), BigInt(1)); // eslint-disable-line no-undef
     });
 }
@@ -156,8 +146,7 @@ test('should rollback DataView object properties', t => {
     const value = new DataView(new ArrayBuffer(4));
     const origValuePropStruct = Object.getOwnPropertyDescriptors(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     Object.assign(value, {
         x: 1,
@@ -169,6 +158,6 @@ test('should rollback DataView object properties', t => {
         origValuePropStruct,
     );
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(Object.getOwnPropertyDescriptors(value), origValuePropStruct);
 });

--- a/test/rollback-value/date.ts
+++ b/test/rollback-value/date.ts
@@ -8,8 +8,7 @@ test('should rollback Date object properties', t => {
     const value = new Date();
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     Object.assign(value, {
         x: 1,
@@ -18,7 +17,7 @@ test('should rollback Date object properties', t => {
     });
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -29,13 +28,12 @@ for (const setterMethodName of getAllPropertyNames(
         const value = new Date(0);
         const origValueStruct = cloneDeep(value);
 
-        const state = new ObjectState();
-        state.set(value);
+        const state = new ObjectState(value);
 
         value[setterMethodName](2);
         t.notDeepEqual(value, origValueStruct);
 
-        state.rollback(value);
+        state.rollback();
         t.deepEqual(value, origValueStruct);
     });
 }

--- a/test/rollback-value/error.ts
+++ b/test/rollback-value/error.ts
@@ -32,8 +32,7 @@ for (const ErrorConstructor of errorConstructorList) {
             const value = new ErrorConstructor('message');
             const origValuePropStruct = Object.getOwnPropertyDescriptors(value);
 
-            const state = new ObjectState();
-            state.set(value);
+            const state = new ObjectState(value);
 
             Object.assign(value, { [prop]: 'str' });
             t.notDeepEqual(
@@ -41,7 +40,7 @@ for (const ErrorConstructor of errorConstructorList) {
                 origValuePropStruct,
             );
 
-            state.rollback(value);
+            state.rollback();
             t.deepEqual(
                 Object.getOwnPropertyDescriptors(value),
                 origValuePropStruct,

--- a/test/rollback-value/map.ts
+++ b/test/rollback-value/map.ts
@@ -13,8 +13,7 @@ test('should rollback Map items', async t => {
     ]);
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.set(
         42,
@@ -23,7 +22,7 @@ test('should rollback Map items', async t => {
     value.delete(NaN);
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -34,8 +33,7 @@ test('should rollback Map object properties', t => {
     ]);
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     Object.assign(value, {
         '0': 0,
@@ -43,7 +41,7 @@ test('should rollback Map object properties', t => {
     });
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -51,8 +49,7 @@ test('should rollback Map items order', async t => {
     const value = new Map([1, 2, 3, 4, 5].map(val => [val, val ** 2]));
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.delete(1);
     value.delete(2);
@@ -66,7 +63,7 @@ test('should rollback Map items order', async t => {
     );
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -85,14 +82,13 @@ test('should rollback nested Map items', t => {
     ]);
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     key.set(NaN, Infinity);
     item.set(false, true);
     value.set(new Map(), null);
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });

--- a/test/rollback-value/object-properties.ts
+++ b/test/rollback-value/object-properties.ts
@@ -16,8 +16,7 @@ test('should rollback object properties', t => {
     };
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     delete value.a;
     Object.assign(value, {
@@ -29,7 +28,7 @@ test('should rollback object properties', t => {
     });
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -49,8 +48,7 @@ test('should rollback object getter / setter properties', t => {
     };
     const origValuePropStruct = Object.getOwnPropertyDescriptors(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.random = null;
     delete value[
@@ -61,7 +59,7 @@ test('should rollback object getter / setter properties', t => {
         origValuePropStruct,
     );
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(Object.getOwnPropertyDescriptors(value), origValuePropStruct);
 });
 
@@ -93,8 +91,7 @@ test('should rollback object non-enumerable properties', t => {
 
     t.deepEqual(Object.keys(value), []);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     delete value.x;
     value.minusZero = 0;
@@ -106,7 +103,7 @@ test('should rollback object non-enumerable properties', t => {
         origValuePropStruct,
     );
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(Object.getOwnPropertyDescriptors(value), origValuePropStruct);
 });
 
@@ -121,15 +118,14 @@ test('should not rollback object prototype properties', t => {
     const origValueStruct = cloneDeep(value);
     const origValueProtoStruct = cloneDeep(Object.getPrototypeOf(value));
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.y = 20;
     Object.getPrototypeOf(value).w = Infinity;
     t.notDeepEqual(value, origValueStruct);
     t.notDeepEqual(Object.getPrototypeOf(value), origValueProtoStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
     t.notDeepEqual(Object.getPrototypeOf(value), origValueProtoStruct);
 });
@@ -147,8 +143,7 @@ test('should rollback nested object properties', t => {
     };
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.a.y = -1;
     Object.assign(value.b, {
@@ -157,7 +152,7 @@ test('should rollback nested object properties', t => {
     });
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -175,12 +170,11 @@ test('should rollback circular object properties', t => {
     Object.assign(value.c, { circular: value });
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.b = 11;
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });

--- a/test/rollback-value/primitive-wrapper.ts
+++ b/test/rollback-value/primitive-wrapper.ts
@@ -18,8 +18,7 @@ for (const PrimitiveWrapperConstructor of primitiveWrapperObjectsConstructorList
         const value = new PrimitiveWrapperConstructor();
         const origValuePropStruct = Object.getOwnPropertyDescriptors(value);
 
-        const state = new ObjectState();
-        state.set(value);
+        const state = new ObjectState(value);
 
         Object.assign(value, {
             hoge: 0,
@@ -30,7 +29,7 @@ for (const PrimitiveWrapperConstructor of primitiveWrapperObjectsConstructorList
             origValuePropStruct,
         );
 
-        state.rollback(value);
+        state.rollback();
         t.deepEqual(
             Object.getOwnPropertyDescriptors(value),
             origValuePropStruct,

--- a/test/rollback-value/regexp.ts
+++ b/test/rollback-value/regexp.ts
@@ -8,8 +8,7 @@ test('should rollback "lastIndex" property', t => {
     const value = /./gu;
     const copiedValue = new RegExp(value.source, value.flags.replace(/g/g, ''));
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     t.is(value.lastIndex, 0);
     t.deepEqual(value.exec(str), copiedValue.exec(str));
@@ -17,7 +16,7 @@ test('should rollback "lastIndex" property', t => {
     t.notDeepEqual(value.exec(str), copiedValue.exec(str));
     t.is(value.lastIndex, 4);
 
-    state.rollback(value);
+    state.rollback();
 
     t.is(value.lastIndex, 0);
     t.deepEqual(value.exec(str), copiedValue.exec(str));
@@ -28,8 +27,7 @@ test('should rollback RegExp object properties', t => {
     const value = /[Rr]eg[Ee]xp?/;
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     Object.assign(value, {
         hoge: 0,
@@ -37,6 +35,6 @@ test('should rollback RegExp object properties', t => {
     });
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });

--- a/test/rollback-value/set.ts
+++ b/test/rollback-value/set.ts
@@ -8,14 +8,13 @@ test('should rollback Set items', async t => {
     const value = new Set([1, null, 'A', true, -3]);
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.add(42);
     value.delete(null);
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -23,8 +22,7 @@ test('should rollback Set object properties', t => {
     const value = new Set([NaN, Infinity]);
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     Object.assign(value, {
         '0': 0,
@@ -32,7 +30,7 @@ test('should rollback Set object properties', t => {
     });
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -40,8 +38,7 @@ test('should rollback Set items order', async t => {
     const value = new Set([1, 2, 3, 4, 5]);
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.delete(1);
     value.delete(2);
@@ -52,7 +49,7 @@ test('should rollback Set items order', async t => {
     t.deepEqual(sortList(value.values()), sortList(origValueStruct.values()));
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });
 
@@ -66,13 +63,12 @@ test('should rollback nested Set items', t => {
     ]);
     const origValueStruct = cloneDeep(value);
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.add(new Set(['a', 'b', 'c']));
     item.delete(2);
     t.notDeepEqual(value, origValueStruct);
 
-    state.rollback(value);
+    state.rollback();
     t.deepEqual(value, origValueStruct);
 });

--- a/test/rollback-value/typed-array.ts
+++ b/test/rollback-value/typed-array.ts
@@ -47,13 +47,12 @@ for (const TypedArrayConstructor of typedArrayConstructorList) {
         setTypedArrayValue(value, 0, 0xff);
         const origValueStruct = value.slice();
 
-        const state = new ObjectState();
-        state.set(value);
+        const state = new ObjectState(value);
 
         setTypedArrayValue(value, 1, 0x07);
         t.notDeepEqual(value, origValueStruct);
 
-        state.rollback(value);
+        state.rollback();
         t.deepEqual(value, origValueStruct);
     });
 
@@ -62,8 +61,7 @@ for (const TypedArrayConstructor of typedArrayConstructorList) {
         setTypedArrayValue(value, 0, 0xff);
         const origValueStruct = value.slice();
 
-        const state = new ObjectState();
-        state.set(value);
+        const state = new ObjectState(value);
 
         Object.assign(value, {
             x: 1,
@@ -72,7 +70,7 @@ for (const TypedArrayConstructor of typedArrayConstructorList) {
         });
         t.notDeepEqual(value, origValueStruct);
 
-        state.rollback(value);
+        state.rollback();
         t.deepEqual(value, origValueStruct);
     });
 }

--- a/test/rollback-value/url.ts
+++ b/test/rollback-value/url.ts
@@ -67,14 +67,13 @@ test('should rollback "?" in URL object query string', t => {
         `if URL's query is empty, the URL object should not remove the "?" at initialize`,
     );
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     for (const [testName, callback] of queryParametersUpdateCallbackMap) {
         callback(value);
         t.not(String(value), origURL, testName);
 
-        state.rollback(value);
+        state.rollback();
         t.is(String(value), origURL, testName);
     }
 });
@@ -90,14 +89,13 @@ test('should not prepend "?" in query string when rollback URL object', t => {
         `if URL's query is empty, the URL object should not add the "?" at initialize`,
     );
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     for (const [testName, callback] of queryParametersUpdateCallbackMap) {
         callback(value);
         t.is(String(value), origURL, testName);
 
-        state.rollback(value);
+        state.rollback();
         t.is(String(value), origURL, testName);
     }
 });
@@ -113,13 +111,12 @@ test('should rollback "#" in URL object fragment', t => {
         `if URL's fragment is empty, the URL object should not remove the "#" at initialize`,
     );
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.hash = value.hash; // eslint-disable-line no-self-assign
     t.not(String(value), origURL);
 
-    state.rollback(value);
+    state.rollback();
     t.is(String(value), origURL);
 });
 
@@ -134,12 +131,11 @@ test('should not prepend "#" in fragment when rollback URL object', t => {
         `if URL's fragment is empty, the URL object should not add the "#" at initialize`,
     );
 
-    const state = new ObjectState();
-    state.set(value);
+    const state = new ObjectState(value);
 
     value.hash = value.hash; // eslint-disable-line no-self-assign
     t.is(String(value), origURL);
 
-    state.rollback(value);
+    state.rollback();
     t.is(String(value), origURL);
 });


### PR DESCRIPTION
Remove the `set()` method and update API so that only one value state can be assigned to each class objects.

Reason: If the newly set value is the property value of the previously set value, the value state may be inconsistent.

```js
const { ObjectState } = require('object-rollback');

const posMap = new Map([ ['x', 0], ['y', 1] ]);
const targetValue = {
  a: 1,
  b: 2,
  c: posMap,
};

const state = new ObjectState();
state.set(targetValue);

// ...
// Very long code. You will have forgotten that the value of `posMap` is already set.
// ...

posMap.set('x', 100);
state.set(posMap); // Error: The specified value has already been set
```

This confusion can be avoided if only one value can be assigned per class.

```js
const { ObjectState } = require('object-rollback');

const posMap = new Map([ ['x', 0], ['y', 1] ]);
const targetValue = {
  a: 1,
  b: 2,
  c: posMap,
};

const state = new ObjectState(targetValue);

// ...
// Very long code.
// ...

posMap.set('x', 100);
const posMapState = new ObjectState(posMap); // 👍
```

---

- [x] Update API tests
- [x] Update source codes
- [x] Update other tests
